### PR TITLE
JavaScriptの新しめの仕様を使わないように修正

### DIFF
--- a/common.js
+++ b/common.js
@@ -516,7 +516,8 @@ function setupEditingTools() {
         addSimpleProcessor("liveeurl", "YouTube配信URL", function(text) {
             for (const key in members_data) {
                 const reftag = `[[${members_data[key].name}>>https://www.youtube.com/channel/${members_data[key].yt}/live]]`;
-                text = text.replaceAll(members_data[key].name, reftag);
+                // text = text.replaceAll(members_data[key].name, reftag);
+                text = text.split(members_data[key].name).join(reftag);
             }
             return text;
         }, (
@@ -712,7 +713,9 @@ function setupEditingTools() {
         const tool_menu = tools_area.querySelector("ul.tool-menu");
         const tool_box = tools_area.querySelector(".tool-box");
 
-        for (const menu_item of tool_menu.childNodes) {
+        // for (const menu_item of tool_menu.childNodes) {
+        for (let i = 0, nodes = tool_menu.childNodes; i < nodes.length; i++) {
+            const menu_item = nodes[i];
             if (menu_item.dataset.toolName === name) {
                 menu_item.addClassName("active");
             } else {
@@ -720,7 +723,9 @@ function setupEditingTools() {
             }
         }
 
-        for (const tool_content of tool_box.childNodes) {
+        // for (const tool_content of tool_box.childNodes) {
+        for (let i = 0, nodes = tool_box.childNodes; i < nodes.length; i++) {
+            const tool_content = nodes[i];
             if (tool_content.dataset.toolName === name) {
                 tool_content.addClassName("show");
             } else {
@@ -929,7 +934,14 @@ function setupSyntaxChecker() {
                 line.type = "heading";
             }
             if (!state.incode && !text.startsWith("//")) {
-                line.anchors = text.match(/(?<=&aname\()[^\)]*(?=\))/g);
+                // XXX: look-behind is not supported
+                // line.anchors = text.match(/(?<=&aname\()[^\)]*(?=\))/g);
+                line.anchors = [];
+                const pattern = /&aname\(([^\)]*)\)/g;
+                let match;
+                while ((match = pattern.exec(text)) !== null) {
+                    line.anchors.push(match[1]);
+                }
             }
         }
 


### PR DESCRIPTION
下記文法は [Can I use...](https://caniuse.com/) とか [ECMAScript compatibility table](https://kangax.github.io/compat-table/es2016plus/) で調べる限り、ここ数年のiOSのブラウザではまだ対応してないものがありそうな雰囲気。

- 正規表現の後読み `/(?<= )/`
  - [common.js#L932](https://github.com/angelic-kitten/unofficialwiki/blob/1e8b71d235abdefb8c89733bded321bef9fab3f4/common.js#L932)
  - https://caniuse.com/js-regexp-lookbehind
- `String.prototype.replaceAll()`
  - [common.js#L519](https://github.com/angelic-kitten/unofficialwiki/blob/1e8b71d235abdefb8c89733bded321bef9fab3f4/common.js#L519)
  - https://caniuse.com/mdn-javascript_builtins_string_replaceall